### PR TITLE
removed premature, unused Document call & object

### DIFF
--- a/mootable.php
+++ b/mootable.php
@@ -32,8 +32,6 @@ class PlgSystemMootable extends JPlugin
 	// Handy objects
 	private $_app    = null;
 
-	private $_doc    = null;
-
 	// Paths
 	private $_pathPlugin = null;
 
@@ -96,7 +94,6 @@ class PlgSystemMootable extends JPlugin
 
 		// Required objects
 		$this->_app = JFactory::getApplication();
-		$this->_doc = JFactory::getDocument();
 
 		// Set the HTML available positions
 		$this->_htmlPositionsAvailable = array_keys($this->_htmlPositions);


### PR DESCRIPTION
This is getting fired before App Routing, thus potentially creating a JDoc object of the wrong type.
