### PR TITLE
Added support for removing jQuery

### DIFF
--- a/language/en-GB/en-GB.plg_system_mootable.ini
+++ b/language/en-GB/en-GB.plg_system_mootable.ini
@@ -9,6 +9,8 @@ PLG_SYS_MOOTABLE_FIELD_DEFAULT_MODE_LABEL="mootools"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MODE_DESC="This will enable/disable mootools by default for your site. You can then fine tunning in menu items"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MOOTOOLS_MORE_LABEL="mootools-more"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MOOTOOLS_MORE_DESC="mootools-more are additional mootools effects/scripts that may conflict with bootstrap. This will enable/disable them globally"
+PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_LABEL="jquery"
+PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_DESC="This will enable/disable jQuery by default for your site."
 
 ; Settings - Additional assets
 PLG_SYS_MOOTABLE_HEADER_ADDITIONAL_ASSETS="Additional assets"

--- a/language/es-ES/es-ES.plg_system_mootable.ini
+++ b/language/es-ES/es-ES.plg_system_mootable.ini
@@ -9,6 +9,8 @@ PLG_SYS_MOOTABLE_FIELD_DEFAULT_MODE_LABEL="mootools"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MODE_DESC="Esto activará/desactivará Mootools por defecto para tu sitio. Después puedes ajustar el modo específico para cada item de menú"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MOOTOOLS_MORE_LABEL="mootools-more"
 PLG_SYS_MOOTABLE_FIELD_DEFAULT_MOOTOOLS_MORE_DESC="mootools-more son efectos/scripts adicionales para Mootools. Pueden entrar en conflicto con Bootstrap. Esto los activará por defecto"
+PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_LABEL="jquery"
+PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_DESC="Esto activará/desactivará jQuery por defecto para tu sitio."
 
 ; Settings - Additional assets
 PLG_SYS_MOOTABLE_HEADER_ADDITIONAL_ASSETS="Archivos adicionales"

--- a/mootable.php
+++ b/mootable.php
@@ -135,8 +135,18 @@ class PlgSystemMootable extends JPlugin
 		// Check if we have to disable Mootools for this item
 		$mootoolsMode = $pageParams->get('mootable', $this->_params->get('defaultMode', 0));
 		$moreMode     = $pageParams->get('moreMode', $this->_params->get('defaultMoreMode', 0));
+		$defaultJQMode = $pageParams->get('defaultJQMode', $this->_params->get('defaultJQMode', 0));
 
 		$disableOnDebug = $this->_params->get('disableWhenDebug', 1);
+
+		if (!$this->_isAutoEnabled() && 0 == $defaultJQMode)
+		{
+			// REMOVE CORE JQUERY
+			unset($doc->_scripts[JURI::root(true) . '/media/jui/js/jquery.min.js']);
+			unset($doc->_scripts[JURI::root(true) . '/media/jui/js/jquery-noconflict.js']);
+			unset($doc->_scripts[JURI::root(true) . '/media/jui/js/jquery-migrate.min.js']);
+			unset($doc->_scripts[JURI::root(true) . '/media/system/js/tabs-state.js']);
+		}
 
 		if (!$this->_isAutoEnabled() && 0 == $mootoolsMode)
 		{

--- a/mootable.xml
+++ b/mootable.xml
@@ -51,6 +51,17 @@
 					<option value="1">JENABLED</option>
 					<option value="0">JDISABLED</option>
 			</field>
+			<field
+				name="defaultJQMode"
+				type="radio"
+				default="0"
+				label="PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_LABEL"
+				description="PLG_SYS_MOOTABLE_FIELD_DEFAULT_JQ_DESC"
+				class="btn-group"
+				>
+					<option value="1">JENABLED</option>
+					<option value="0">JDISABLED</option>
+			</field>
 			<field type="header" name="header1" label="PLG_SYS_MOOTABLE_HEADER_ADDITIONAL_ASSETS" />
 			<field
 				name="manualDisable"


### PR DESCRIPTION
Just a minor add to let user remove J3.2 jQuery in frontend. To avoid conflict with other scripts.
